### PR TITLE
Feature/issues26

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,9 @@ class ApplicationController < ActionController::Base
   end
 
   def layout_by_resource
-    if devise_controller?
+    # deviseでの新規登録・ログインはaction_name == 'new' として実行するため"devise-application"を選択する
+    # ログイン後の画面（パスワード変更・ユーザー情報変更などのセッション維持されているもの)は"application"を選択する
+    if devise_controller? && resource_name == :user && action_name == 'new'
       "devise-application"
     else
       "application"

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,12 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
+  end
+
+  def after_update_path_for(resource)
+    users_path(resource)
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,20 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, password_length: 8..128
   validates :name,
-            length: { minimum: 2, maximum: 20 }
+            length: {minimum: 2, maximum: 20}
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password) #＊params.delete(:current_password) で current_password のパラメータを削除。
+
+    if params[:password].blank? && params[:password_confirmation].blank? #＊パスワード変更のためのパスワード入力フィールドとその確認フィールドの両者とも空の場合のみ、パスワードなしで更新できるようにするためです。
+
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,14 +3,14 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+<!--  <div class="field">-->
+<!--    <%#= f.label :email %><br />-->
+    <%#= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<!--  </div>-->
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+  <%# if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+<!--    <div>Currently waiting confirmation for: <%#= resource.unconfirmed_email %></div>-->
+  <%# end %>
 
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
@@ -26,10 +26,10 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
+<!--  <div class="field">-->
+<!--    <%#= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />-->
+    <%#= f.password_field :current_password, autocomplete: "current-password" %>
+<!--  </div>-->
 
   <div class="actions">
     <%= f.submit "Update" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,40 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+  <main class="py-4" id="main-content">
+    <div class="container gt-main-container">
+      <div class="row justify-content-center">
+        <div class="col-md-11 body-frame">
+          <div class="card">
+            <div class="card-header bg-primary text-white font-weight-bold">パスワード更新</div>
 
-<!--  <div class="field">-->
-<!--    <%#= f.label :email %><br />-->
-    <%#= f.email_field :email, autofocus: true, autocomplete: "email" %>
-<!--  </div>-->
+            <div class="card-body">
 
-  <%# if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-<!--    <div>Currently waiting confirmation for: <%#= resource.unconfirmed_email %></div>-->
-  <%# end %>
+              <form method="POST" action="https://grouptask.biz/user/edit_password" class="ajax-form" id="ajaxForm">
+                <input type="hidden" name="_token" value="uQ2gsjwMuxZ4HhEiPT5FFOBDu35QBs3JMd5I8PFQ">
+                <input type="hidden" name="_method" value="put">
+                <div class="form-group">
+                  <%= f.label :password, 'パスワード', class: "control-label" %>
+                  <span class="badge badge-danger">必須</span>
+                  <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'form-control' %>
+                </div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
+                <div class="form-group">
+                  <%= f.label :password_confirmation, class: "control-label" %><br/>
+                  <%= f.password_field :password_confirmation, autofocus: true, autocomplete: "new-password", class: 'form-control' %>
+                </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-<!--  <div class="field">-->
-<!--    <%#= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />-->
-    <%#= f.password_field :current_password, autocomplete: "current-password" %>
-<!--  </div>-->
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
+                <div class="form-group">
+                  <%= f.submit "更新", class: 'btn btn-primary d-block' %>
+                  </button>
+                </div>
+              </form>
 <% end %>
 
-<h3>Cancel my account</h3>
+</div>
+</div>
+</div>
+</div>
+</div>
+</main>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
-<%= link_to "Back", :back %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -12,6 +12,8 @@
       </td>
       <td align="right">
         <%= link_to "削除", user_path(user), method: :delete, data: {confirm: "削除しますか？"} %>
+        <%= link_to "change", edit_user_registration_path %>
+
       </td>
     </tr>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'tasks/new' => 'tasks#new'
-  devise_for :users
+  devise_for :users,controllers: { registrations: 'registrations' }
   root 'homes#index'
   resources :users
   resources :tasks, only: [:index]


### PR DESCRIPTION
# #31 
## what
- ログインユーザーのパスワード変更機能とマークアップを行った。
[見本のページURL](https://grouptask.biz/user/edit_password)

## why
- ユーザーはパスワードを変更することが出来る
- パスワードを変更する際に現在使用しているパスワードの入力を不要にした
- deviseの機能を利用しているが、新規登録とログイン時のnavbar(devise-nav)、それ以外のnavbarでは適用先が違うため新規でメソッドを設け、制御させることで達成した。

## shareimage
- gif化します。お待ち下さい。

## check
- app/controller/application_controller.rb
- app/views/devise/registrations/edit.html.erb

##  参考リンク
### 新パスワードのみでパスワード更新
https://qiita.com/tatsuya1156/items/7b5bf5cf9953dc080c47

### パスワード更新後のリダイレクト先
https://qiita.com/nekojoker/items/95e9685e908c44931195

### deviseの新規登録、ログイン時のみlayout参照先変更
https://www.it-swarm.dev/ja/ruby-on-rails/devise%E3%81%AEsignin%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E7%95%B0%E3%81%AA%E3%82%8B%E3%83%AC%E3%82%A4%E3%82%A2%E3%82%A6%E3%83%88/971663285/

